### PR TITLE
fix: show latency in millisecond

### DIFF
--- a/src/common/formatter.ts
+++ b/src/common/formatter.ts
@@ -3,5 +3,5 @@ export const formatThousandSeparated = (value: number, separator = " ") => {
 };
 
 export const formatLatency = (value: number) => {
-  return `${value} ms`;
+  return `${(value/1000).toFixed(2)} ms`;
 };


### PR DESCRIPTION
Fix: https://github.com/the-benchmarker/website/issues/29

Retains two decimal points(`toFixed(2)`), 0.01 ms precision is enough for api benchmarks.

<img width="1189" alt="image" src="https://user-images.githubusercontent.com/59005238/210068912-e45657e5-5768-4fe0-9436-40a013dd9384.png">
