### PR TITLE
fix latencies in /result and /compare

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -95,7 +95,7 @@ const metricsToObject = (metrics: Metric[], level: Metric["level"]) => {
     metrics
       .filter((m) => m.level === level)
       .reduce((obj, curr) => {
-        obj[curr.label] = Math.round(curr.value * 10) / 10;
+        obj[curr.label] = Math.round(curr.value * 100_000) / 100_000;
         return obj;
       }, {} as Record<MetricTypes, number>)
   );

--- a/src/common/formatter.ts
+++ b/src/common/formatter.ts
@@ -3,5 +3,5 @@ export const formatThousandSeparated = (value: number, separator = " ") => {
 };
 
 export const formatLatency = (value: number) => {
-  return `${(value/1000).toFixed(2)} ms`;
+  return `${(value * 1000).toFixed(2)} ms`;
 };

--- a/src/views/CompareFramework.tsx
+++ b/src/views/CompareFramework.tsx
@@ -15,6 +15,7 @@ import FrameworkSelector, {
   SelectOptionFramework,
 } from "../components/FrameworkSelector";
 import { BenchmarkDataSet } from "../App";
+import type { MetricTypes } from "../api";
 import { COMPARED_METRICS, CONCURRENCIES, ComparedMetric } from "../common";
 import { parseAsArrayOf, parseAsString, useQueryState } from "nuqs";
 
@@ -54,7 +55,11 @@ function CompareFramework({ benchmarks }: Props) {
 
         const datasets = benchmarks.map((b) => ({
           ...b,
-          data: CONCURRENCIES.map((c) => b[`level${c}` as const][metric.key]),
+          data: CONCURRENCIES.map((c) => {
+            let value = b[`level${c}` as const][metric.key];
+            if (isLatencyMetric(metric.key)) value *= 1000;
+            return value;
+          }),
         }));
 
         return {
@@ -175,5 +180,17 @@ function CompareFramework({ benchmarks }: Props) {
     </div>
   );
 }
+
+const LATENCY_METRICS: MetricTypes[] = [
+  "percentile50",
+  "percentile75",
+  "percentile90",
+  "percentile99",
+  "percentile99999",
+  "averageLatency",
+  "minimumLatency",
+  "maximumLatency",
+];
+const isLatencyMetric = (k: MetricTypes) => LATENCY_METRICS.includes(k);
 
 export default CompareFramework;


### PR DESCRIPTION
Fixes latencies (mostly) in /result and /compare views

Latencies in `data.min.json` are in seconds so they are converted to ms via `* 1000` not `/ 1000`.

Also, since the values are like ~0.005 they need more significant digits (changed from 1 digit to 5).

Note:

* `percentile99999`
* `averageLatency`
* `minimumLatency`
* `maximumLatency`

have invalid values so they are still broken.