### PR TITLE
Pre-render a page per framework, and add the SEO files the SPA cannot serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,21 @@ npm run dev
 
 ---
 
+### Pre-rendered pages
+
+The app renders on the client, so a crawler that does not run JavaScript sees an empty
+page. `npm run build` therefore runs the Vite build and then `scripts/seo/build.mjs`,
+which reads the benchmark dataset and writes into `dist/`:
+
+- a static, no-JavaScript page per framework (`/frameworks/<language>/<framework>/`) and
+  per language (`/frameworks/<language>/`), with the numbers in a real table
+- `sitemap.xml`, `robots.txt`, `llms.txt`, `llms-full.txt` and `data.json`
+- canonical, Open Graph and JSON-LD tags on `dist/index.html`
+
+Run it alone with `npm run seo` after a build. `VITE_SITE_URL` sets the canonical host,
+`SEO_DATA_FILE` reads the dataset from a local file instead of GitHub. The pages hold the
+data of the build, so the site needs a rebuild when the benchmark is re-run.
+
+---
+
 Built with [React](https://github.com/facebook/react)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,4 +28,15 @@ export default defineConfig([
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
+  {
+    files: ["scripts/**/*.mjs"],
+    languageOptions: {
+      globals: globals.node,
+    },
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+  },
 ]);

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/seo/build.mjs",
     "preview": "vite preview",
+    "seo": "node scripts/seo/build.mjs",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-# https://www.robotstxt.org/robotstxt.html
-User-agent: *
-Disallow:

--- a/scripts/seo/build.mjs
+++ b/scripts/seo/build.mjs
@@ -1,0 +1,539 @@
+// Post build step. The app is a single page bundle, so search engines and LLM
+// crawlers see an empty <div id="root"> and nothing else. This writes a static,
+// no-JavaScript page for every framework and every language next to the bundle,
+// plus the usual robots/sitemap/llms files.
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { CONCURRENCIES, METRICS, loadBenchmark } from "./data.mjs";
+import {
+  SITE_URL,
+  absolute,
+  escapeHtml,
+  formatMetric,
+  jsonLd,
+  metricTable,
+  page,
+  rankingTable,
+} from "./render.mjs";
+
+const DIST = fileURLToPath(new URL("../../dist/", import.meta.url));
+
+// Every metric goes in the table, only these go in the structured data.
+const HEADLINE_METRICS = METRICS.filter((metric) =>
+  ["total_requests_per_s", "percentile50", "percentile99", "average_latency"].includes(metric.key)
+);
+
+const written = [];
+
+const write = async (path, content) => {
+  const file = join(DIST, path);
+  await mkdir(dirname(file), { recursive: true });
+  await writeFile(file, content);
+  written.push(path);
+};
+
+const home = { name: "Home", path: "/" };
+const hub = { name: "Frameworks", path: "/frameworks/" };
+
+const summary = (framework) => {
+  const level = CONCURRENCIES[0];
+  return (
+    `${framework.label} ${framework.version} is a ${framework.language.label} web framework. ` +
+    `At concurrency ${level} it serves ${formatMetric(
+      "rps",
+      framework.levels[level].total_requests_per_s
+    )} requests per second with a P50 latency of ${formatMetric(
+      "latency",
+      framework.levels[level].percentile50
+    )}, ranking ${framework.rank[level]} of ${framework.totalCount} overall and ` +
+    `${framework.languageRank[level]} of ${framework.language.frameworks.length} among ` +
+    `${framework.language.label} frameworks.`
+  );
+};
+
+const frameworkPage = (framework, benchmark) => {
+  const trail = [
+    home,
+    hub,
+    { name: framework.language.label, path: framework.language.path },
+    { name: framework.label, path: framework.path },
+  ];
+
+  const peers = framework.language.frameworks.filter((f) => f !== framework).slice(0, 10);
+
+  const body = `
+<h2>${escapeHtml(framework.label)} ${escapeHtml(framework.version)} benchmark results</h2>
+<p>${escapeHtml(summary(framework))}</p>
+<ul>
+<li>Language: <a href="${framework.language.path}">${escapeHtml(
+    framework.language.label
+  )}</a> ${escapeHtml(framework.language.version)}</li>
+<li>Framework version: ${escapeHtml(framework.version)}</li>
+${framework.website ? `<li>Website: <a href="${escapeHtml(framework.website)}" rel="nofollow">${escapeHtml(framework.website)}</a></li>` : ""}
+<li>Open in the interactive charts: <a href="/compare?f=${encodeURIComponent(
+    framework.label
+  )}">compare ${escapeHtml(framework.label)}</a></li>
+</ul>
+${metricTable(framework, `All measured metrics for ${framework.label} ${framework.version}, by concurrency level.`)}
+<h3>Rank</h3>
+<div class="table-wrap">
+<table>
+<caption>Position of ${escapeHtml(framework.label)} on requests per second.</caption>
+<thead><tr><th scope="col">Concurrency</th><th scope="col">Overall</th><th scope="col">Among ${escapeHtml(
+    framework.language.label
+  )} frameworks</th></tr></thead>
+<tbody>
+${CONCURRENCIES.map(
+  (level) =>
+    `<tr><th scope="row">${level}</th><td>${framework.rank[level]} of ${framework.totalCount}</td><td>${framework.languageRank[level]} of ${framework.language.frameworks.length}</td></tr>`
+).join("\n")}
+</tbody>
+</table>
+</div>
+${
+  peers.length
+    ? `<h3>Other ${escapeHtml(framework.language.label)} frameworks</h3>
+${rankingTable({
+  frameworks: peers,
+  caption: `Fastest ${framework.language.label} frameworks at concurrency ${CONCURRENCIES[0]}.`,
+  rankField: "languageRank",
+  showLanguage: false,
+})}
+<p><a href="${framework.language.path}">All ${framework.language.frameworks.length} ${escapeHtml(
+        framework.language.label
+      )} frameworks</a></p>`
+    : ""
+}`;
+
+  const structured = [
+    jsonLd({
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      name: framework.label,
+      applicationCategory: "DeveloperApplication",
+      softwareVersion: String(framework.version),
+      programmingLanguage: framework.language.label,
+      ...(framework.website ? { url: framework.website } : {}),
+      subjectOf: {
+        "@type": "Dataset",
+        name: `${framework.label} ${framework.version} benchmark measurements`,
+        description: summary(framework),
+        url: absolute(framework.path),
+        license: "https://github.com/the-benchmarker/web-frameworks/blob/master/LICENSE",
+        isBasedOn: "https://github.com/the-benchmarker/web-frameworks",
+        dateModified: benchmark.updatedAtDate,
+        variableMeasured: CONCURRENCIES.flatMap((level) =>
+          HEADLINE_METRICS.map((metric) => ({
+            "@type": "PropertyValue",
+            name: `${metric.title} at concurrency ${level}`,
+            value: framework.levels[level][metric.key],
+            unitText: metric.kind === "latency" ? "s" : undefined,
+          }))
+        ),
+      },
+    }),
+  ];
+
+  return page({
+    title: `${framework.label} ${framework.version} benchmark (${framework.language.label}) - Web Frameworks Benchmark`,
+    description: summary(framework),
+    path: framework.path,
+    trail,
+    structured,
+    body,
+    benchmark,
+  });
+};
+
+const languagePage = (language, benchmark) => {
+  const trail = [home, hub, { name: language.label, path: language.path }];
+  const fastest = language.frameworks[0];
+  const description =
+    `Benchmark results for ${language.frameworks.length} ${language.label} web frameworks, ` +
+    `measured with wrk at concurrency ${CONCURRENCIES.join(", ")}. Fastest at concurrency ` +
+    `${CONCURRENCIES[0]}: ${fastest.label} with ${formatMetric(
+      "rps",
+      fastest.levels[CONCURRENCIES[0]].total_requests_per_s
+    )} requests per second.`;
+
+  const body = `
+<h2>${escapeHtml(language.label)} web framework benchmarks</h2>
+<p>${escapeHtml(description)}</p>
+${CONCURRENCIES.map((level) =>
+  rankingTable({
+    frameworks: [...language.frameworks].sort(
+      (a, b) => a.languageRank[level] - b.languageRank[level]
+    ),
+    caption: `${language.label} frameworks at concurrency ${level}, ranked on requests per second.`,
+    level,
+    rankField: "languageRank",
+    showLanguage: false,
+  })
+).join("\n")}`;
+
+  const structured = [
+    jsonLd({
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      name: `${language.label} web framework benchmark`,
+      description,
+      url: absolute(language.path),
+      license: "https://github.com/the-benchmarker/web-frameworks/blob/master/LICENSE",
+      isBasedOn: "https://github.com/the-benchmarker/web-frameworks",
+      dateModified: benchmark.updatedAtDate,
+      creator: {
+        "@type": "Organization",
+        name: "The Benchmarker",
+        url: "https://github.com/the-benchmarker",
+      },
+    }),
+    jsonLd({
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: `${language.label} web frameworks`,
+      numberOfItems: language.frameworks.length,
+      itemListElement: language.frameworks.map((framework, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: framework.label,
+        url: absolute(framework.path),
+      })),
+    }),
+  ];
+
+  return page({
+    title: `${language.label} web framework benchmark - Web Frameworks Benchmark`,
+    description,
+    path: language.path,
+    trail,
+    structured,
+    body,
+    benchmark,
+  });
+};
+
+const hubPage = (benchmark) => {
+  const trail = [home, hub];
+  const level = CONCURRENCIES[0];
+  const top = [...benchmark.frameworks].sort((a, b) => a.rank[level] - b.rank[level]).slice(0, 50);
+  const description =
+    `Benchmark results for ${benchmark.frameworks.length} web frameworks in ` +
+    `${benchmark.languages.length} languages, measured with wrk at concurrency ` +
+    `${CONCURRENCIES.join(", ")}. Data of ${benchmark.updatedAtDate}.`;
+
+  const body = `
+<h2>All benchmarked frameworks</h2>
+<p>${escapeHtml(description)}</p>
+<h3>Languages</h3>
+<ul class="grid">
+${benchmark.languages
+  .map(
+    (language) =>
+      `<li><a href="${language.path}">${escapeHtml(language.label)}</a> <span class="muted">${
+        language.frameworks.length
+      }</span></li>`
+  )
+  .join("\n")}
+</ul>
+<h3>Fastest 50 overall</h3>
+${rankingTable({
+  frameworks: top,
+  caption: `The 50 fastest frameworks at concurrency ${level}, ranked on requests per second.`,
+  level,
+})}
+<p><a href="/result">See all ${benchmark.frameworks.length} frameworks in the interactive table</a></p>`;
+
+  const structured = [
+    jsonLd({
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      name: "Web Frameworks Benchmark",
+      description,
+      url: absolute("/frameworks/"),
+      license: "https://github.com/the-benchmarker/web-frameworks/blob/master/LICENSE",
+      isBasedOn: "https://github.com/the-benchmarker/web-frameworks",
+      dateModified: benchmark.updatedAtDate,
+      keywords: benchmark.languages.map((language) => language.label),
+      distribution: [
+        {
+          "@type": "DataDownload",
+          encodingFormat: "application/json",
+          contentUrl: absolute("/data.json"),
+        },
+      ],
+      creator: {
+        "@type": "Organization",
+        name: "The Benchmarker",
+        url: "https://github.com/the-benchmarker",
+      },
+    }),
+  ];
+
+  return page({
+    title: "All benchmarked web frameworks - Web Frameworks Benchmark",
+    description,
+    path: "/frameworks/",
+    trail,
+    structured,
+    body,
+    benchmark,
+  });
+};
+
+// The bundle renders into an empty <div id="root">. Add the head tags that the
+// app cannot produce before it boots, and a <noscript> ranking so a reader
+// without JavaScript still gets the numbers and a way into the static pages.
+const patchIndex = async (benchmark) => {
+  const file = join(DIST, "index.html");
+  let html = await readFile(file, "utf8");
+  const level = CONCURRENCIES[0];
+  const top = [...benchmark.frameworks].sort((a, b) => a.rank[level] - b.rank[level]).slice(0, 25);
+  const description =
+    `Performance comparison of ${benchmark.frameworks.length} web frameworks in ` +
+    `${benchmark.languages.length} languages, measured with wrk at concurrency ` +
+    `${CONCURRENCIES.join(", ")}. Data of ${benchmark.updatedAtDate}.`;
+
+  const head = `
+<link rel="canonical" href="${absolute("/")}">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Web Frameworks Benchmark">
+<meta property="og:title" content="Web Frameworks Benchmark">
+<meta property="og:description" content="${escapeHtml(description)}">
+<meta property="og:url" content="${absolute("/")}">
+<meta property="og:image" content="${absolute("/logo512.png")}">
+<meta name="twitter:card" content="summary">
+${jsonLd({
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Web Frameworks Benchmark",
+  url: absolute("/"),
+})}
+${jsonLd({
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  name: "Web Frameworks Benchmark",
+  description,
+  url: absolute("/"),
+  license: "https://github.com/the-benchmarker/web-frameworks/blob/master/LICENSE",
+  isBasedOn: "https://github.com/the-benchmarker/web-frameworks",
+  dateModified: benchmark.updatedAtDate,
+  keywords: benchmark.languages.map((language) => language.label),
+  distribution: [
+    {
+      "@type": "DataDownload",
+      encodingFormat: "application/json",
+      contentUrl: absolute("/data.json"),
+    },
+  ],
+  creator: {
+    "@type": "Organization",
+    name: "The Benchmarker",
+    url: "https://github.com/the-benchmarker",
+  },
+})}
+`;
+
+  const noscript = `<noscript>
+<h1>Web Frameworks Benchmark</h1>
+<p>${escapeHtml(description)}</p>
+<table>
+<caption>The 25 fastest frameworks at concurrency ${level}, ranked on requests per second.</caption>
+<thead><tr><th scope="col">#</th><th scope="col">Framework</th><th scope="col">Language</th><th scope="col">Requests / second</th></tr></thead>
+<tbody>
+${top
+  .map(
+    (framework) =>
+      `<tr><td>${framework.rank[level]}</td><th scope="row"><a href="${
+        framework.path
+      }">${escapeHtml(framework.label)}</a></th><td><a href="${
+        framework.language.path
+      }">${escapeHtml(framework.language.label)}</a></td><td>${escapeHtml(
+        formatMetric("rps", framework.levels[level].total_requests_per_s)
+      )}</td></tr>`
+  )
+  .join("\n")}
+</tbody>
+</table>
+<p><a href="/frameworks/">All ${benchmark.frameworks.length} frameworks in ${
+    benchmark.languages.length
+  } languages</a></p>
+</noscript>`;
+
+  html = html.replace("</head>", `${head}</head>`);
+  html = html.replace(
+    '<div id="root"></div>',
+    `<div id="root"></div>\n    ${noscript}`
+  );
+  await writeFile(file, html);
+  written.push("index.html (patched)");
+};
+
+const sitemap = (benchmark) => {
+  const urls = [
+    { path: "/", priority: "1.0" },
+    { path: "/result", priority: "0.9" },
+    { path: "/compare", priority: "0.9" },
+    { path: "/frameworks/", priority: "0.9" },
+    ...benchmark.languages.map((language) => ({ path: language.path, priority: "0.8" })),
+    ...benchmark.frameworks.map((framework) => ({ path: framework.path, priority: "0.7" })),
+  ];
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls
+  .map(
+    ({ path, priority }) =>
+      `  <url><loc>${absolute(path)}</loc><lastmod>${benchmark.updatedAtDate}</lastmod><changefreq>daily</changefreq><priority>${priority}</priority></url>`
+  )
+  .join("\n")}
+</urlset>
+`;
+};
+
+// `sha` replays an old commit of the dataset, so it is an unbounded set of URLs
+// that all show the same page. Everything else is worth crawling.
+const robots = () => `# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Allow: /
+Disallow: /*?*sha=
+
+Sitemap: ${absolute("/sitemap.xml")}
+`;
+
+const llms = (benchmark) => {
+  const level = CONCURRENCIES[0];
+  const top = [...benchmark.frameworks].sort((a, b) => a.rank[level] - b.rank[level]).slice(0, 25);
+
+  return `# Web Frameworks Benchmark
+
+> Throughput and latency of ${benchmark.frameworks.length} web frameworks in ${
+    benchmark.languages.length
+  } languages, all serving the same two routes from a Docker container, measured with wrk (8 threads, 15 seconds) at concurrency ${CONCURRENCIES.join(
+    ", "
+  )}. Run by The Benchmarker. Data of ${benchmark.updatedAtDate}.
+
+Hardware: ${benchmark.hardware?.cpus ?? "?"} cores (${
+    benchmark.hardware?.cpu_name ?? "unknown CPU"
+  }), ${Math.round((benchmark.hardware?.memory ?? 0) / 1024 / 1024)} GB RAM, ${
+    benchmark.hardware?.os?.sysname ?? "Linux"
+  }. Latency figures are seconds in the raw data and milliseconds on the site.
+
+## Fastest ${top.length} frameworks at concurrency ${level}
+
+${top
+  .map(
+    (framework) =>
+      `- [${framework.label} ${framework.version} (${framework.language.label})](${absolute(
+        framework.path
+      )}): ${formatMetric(
+        "rps",
+        framework.levels[level].total_requests_per_s
+      )} req/s, P50 ${formatMetric("latency", framework.levels[level].percentile50)}`
+  )
+  .join("\n")}
+
+## Languages
+
+${benchmark.languages
+  .map(
+    (language) =>
+      `- [${language.label}](${absolute(language.path)}): ${
+        language.frameworks.length
+      } frameworks, fastest ${language.frameworks[0].label}`
+  )
+  .join("\n")}
+
+## Full data
+
+- [llms-full.txt](${absolute("/llms-full.txt")}): every framework with every metric
+- [data.json](${absolute("/data.json")}): the same as JSON
+- [All frameworks](${absolute("/frameworks/")}): index of the per framework pages
+- [web-frameworks](https://github.com/the-benchmarker/web-frameworks): the benchmark itself
+`;
+};
+
+const llmsFull = (benchmark) => {
+  const lines = [
+    `# Web Frameworks Benchmark, full results`,
+    ``,
+    `Data of ${benchmark.updatedAtDate}. ${benchmark.frameworks.length} frameworks, ${benchmark.languages.length} languages.`,
+    `Measured with wrk, 8 threads, 8s timeout, 15s per run, at concurrency ${CONCURRENCIES.join(", ")}.`,
+    `Hardware: ${benchmark.hardware?.cpus ?? "?"} cores (${
+      benchmark.hardware?.cpu_name ?? "unknown CPU"
+    }), ${benchmark.hardware?.os?.sysname ?? "Linux"}.`,
+    `Latency values below are milliseconds.`,
+    ``,
+  ];
+
+  for (const language of benchmark.languages) {
+    lines.push(`## ${language.label} (${language.frameworks.length} frameworks)`, ``);
+    for (const framework of language.frameworks) {
+      lines.push(`### ${framework.label} ${framework.version} (${language.label})`);
+      lines.push(`url: ${absolute(framework.path)}`);
+      if (framework.website) lines.push(`website: ${framework.website}`);
+      for (const level of CONCURRENCIES) {
+        const values = framework.levels[level];
+        lines.push(
+          `concurrency ${level}: ` +
+            METRICS.map(
+              (metric) => `${metric.key}=${formatMetric(metric.kind, values[metric.key])}`
+            ).join(", ") +
+            `, rank=${framework.rank[level]}/${benchmark.frameworks.length}` +
+            `, rank in ${language.label}=${framework.languageRank[level]}/${language.frameworks.length}`
+        );
+      }
+      lines.push(``);
+    }
+  }
+
+  return lines.join("\n");
+};
+
+const dataJson = (benchmark) =>
+  JSON.stringify({
+    updatedAt: benchmark.updatedAt,
+    source: "https://github.com/the-benchmarker/web-frameworks",
+    concurrencies: CONCURRENCIES,
+    latencyUnit: "second",
+    hardware: benchmark.hardware,
+    frameworks: benchmark.frameworks.map((framework) => ({
+      label: framework.label,
+      version: framework.version,
+      language: framework.language.label,
+      languageVersion: framework.language.version,
+      website: framework.website,
+      url: absolute(framework.path),
+      rank: framework.rank,
+      languageRank: framework.languageRank,
+      levels: framework.levels,
+    })),
+  });
+
+const main = async () => {
+  const benchmark = await loadBenchmark();
+  for (const framework of benchmark.frameworks) framework.totalCount = benchmark.frameworks.length;
+
+  await write("frameworks/index.html", hubPage(benchmark));
+  for (const language of benchmark.languages) {
+    await write(`${language.path.slice(1)}index.html`, languagePage(language, benchmark));
+  }
+  for (const framework of benchmark.frameworks) {
+    await write(`${framework.path.slice(1)}index.html`, frameworkPage(framework, benchmark));
+  }
+
+  await write("sitemap.xml", sitemap(benchmark));
+  await write("robots.txt", robots());
+  await write("llms.txt", llms(benchmark));
+  await write("llms-full.txt", llmsFull(benchmark));
+  await write("data.json", dataJson(benchmark));
+  await patchIndex(benchmark);
+
+  console.log(
+    `[seo] ${written.length} files for ${benchmark.frameworks.length} frameworks in ` +
+      `${benchmark.languages.length} languages, canonical host ${SITE_URL}`
+  );
+};
+
+await main();

--- a/scripts/seo/data.mjs
+++ b/scripts/seo/data.mjs
@@ -1,0 +1,165 @@
+// Loads the benchmark dataset that the app fetches at runtime and reshapes it
+// into what the static pages need: slugs, per level metrics and rankings.
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const DATA_URL =
+  "https://raw.githubusercontent.com/the-benchmarker/web-frameworks/master/data.min.json";
+const CACHE_FILE = new URL("../../node_modules/.cache/seo/data.min.json", import.meta.url);
+
+// The three concurrency levels wrk is run with, see the "Technical Details"
+// section of the home page.
+export const CONCURRENCIES = [64, 256, 512];
+
+// Every metric the dataset carries, in the order they are shown in the tables.
+// `maximum_latency` is listed by the app but is not published upstream.
+export const METRICS = [
+  { key: "total_requests_per_s", title: "Requests / second", kind: "rps" },
+  { key: "percentile50", title: "P50 latency", kind: "latency" },
+  { key: "percentile75", title: "P75 latency", kind: "latency" },
+  { key: "percentile90", title: "P90 latency", kind: "latency" },
+  { key: "percentile99", title: "P99 latency", kind: "latency" },
+  { key: "percentile99999", title: "P99.999 latency", kind: "latency" },
+  { key: "average_latency", title: "Average latency", kind: "latency" },
+  { key: "minimum_latency", title: "Minimum latency", kind: "latency" },
+  { key: "standard_deviation", title: "Standard deviation", kind: "latency" },
+  { key: "total_requests", title: "Total requests", kind: "count" },
+  { key: "total_bytes_received", title: "Bytes received", kind: "bytes" },
+  { key: "http_errors", title: "HTTP errors", kind: "count" },
+  { key: "request_timeouts", title: "Request timeouts", kind: "count" },
+  { key: "socket_connection_errors", title: "Socket connection errors", kind: "count" },
+  { key: "socket_read_errors", title: "Socket read errors", kind: "count" },
+  { key: "socket_write_errors", title: "Socket write errors", kind: "count" },
+];
+
+export const slugify = (value) =>
+  String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+const fetchDataset = async () => {
+  const local = process.env.SEO_DATA_FILE;
+  if (local) return JSON.parse(await readFile(local, "utf8"));
+
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const response = await fetch(DATA_URL);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const body = await response.text();
+      await mkdir(dirname(CACHE_FILE.pathname.slice(1)), { recursive: true }).catch(() => {});
+      await writeFile(CACHE_FILE, body).catch(() => {});
+      return JSON.parse(body);
+    } catch (error) {
+      lastError = error;
+      console.warn(`[seo] fetch of data.min.json failed (${attempt}/3): ${error.message}`);
+    }
+  }
+
+  try {
+    console.warn("[seo] falling back to the cached dataset");
+    return JSON.parse(await readFile(CACHE_FILE, "utf8"));
+  } catch {
+    throw lastError;
+  }
+};
+
+// Same rule the app applies: a framework is shown only when it has every
+// metric at every concurrency level, so a partial run cannot fake a ranking.
+const isComplete = (metricsById, frameworkId, labels) => {
+  const byLabel = metricsById.get(frameworkId);
+  if (!byLabel) return false;
+  return labels.every((label) => {
+    const levels = byLabel.get(label);
+    return levels && CONCURRENCIES.every((level) => levels.has(level));
+  });
+};
+
+const rank = (frameworks, level, field) => {
+  const sorted = [...frameworks].sort(
+    (a, b) => b.levels[level].total_requests_per_s - a.levels[level].total_requests_per_s
+  );
+  sorted.forEach((framework, index) => {
+    framework[field][level] = index + 1;
+  });
+};
+
+export const loadBenchmark = async () => {
+  const raw = await fetchDataset();
+
+  const labels = [...new Set(raw.metrics.map((m) => m.label))];
+  const metricsById = new Map();
+  for (const metric of raw.metrics) {
+    let byLabel = metricsById.get(metric.framework_id);
+    if (!byLabel) metricsById.set(metric.framework_id, (byLabel = new Map()));
+    let levels = byLabel.get(metric.label);
+    if (!levels) byLabel.set(metric.label, (levels = new Map()));
+    levels.set(metric.level, metric.value);
+  }
+
+  const languages = new Map();
+  for (const language of raw.languages) {
+    languages.set(language.label, {
+      label: language.label,
+      version: language.version,
+      slug: slugify(language.label),
+      path: `/frameworks/${slugify(language.label)}/`,
+      frameworks: [],
+    });
+  }
+
+  const frameworks = [];
+  for (const entry of raw.frameworks) {
+    if (!isComplete(metricsById, entry.id, labels)) continue;
+    const language = languages.get(entry.language);
+    if (!language) continue;
+
+    const byLabel = metricsById.get(entry.id);
+    const levels = {};
+    for (const level of CONCURRENCIES) {
+      levels[level] = Object.fromEntries(
+        labels.map((label) => [label, byLabel.get(label).get(level)])
+      );
+    }
+
+    const framework = {
+      id: entry.id,
+      label: entry.label,
+      slug: slugify(entry.label),
+      version: entry.version,
+      website: entry.website,
+      language,
+      path: `/frameworks/${language.slug}/${slugify(entry.label)}/`,
+      levels,
+      rank: {},
+      languageRank: {},
+    };
+    frameworks.push(framework);
+    language.frameworks.push(framework);
+  }
+
+  for (const level of CONCURRENCIES) {
+    rank(frameworks, level, "rank");
+    for (const language of languages.values()) {
+      rank(language.frameworks, level, "languageRank");
+    }
+  }
+
+  const byThroughput = (a, b) =>
+    b.levels[64].total_requests_per_s - a.levels[64].total_requests_per_s;
+  frameworks.sort(byThroughput);
+  const languageList = [...languages.values()].filter((l) => l.frameworks.length);
+  for (const language of languageList) language.frameworks.sort(byThroughput);
+  languageList.sort((a, b) => a.label.localeCompare(b.label));
+
+  const updatedAt = String(raw.updated_at || "").trim();
+
+  return {
+    updatedAt,
+    updatedAtDate: updatedAt.split(" ")[0],
+    hardware: raw.hardware,
+    frameworks,
+    languages: languageList,
+  };
+};

--- a/scripts/seo/render.mjs
+++ b/scripts/seo/render.mjs
@@ -1,0 +1,234 @@
+// Templates for the static pages. They are plain HTML on purpose: crawlers and
+// LLM readers get the numbers without running the app bundle.
+import { CONCURRENCIES, METRICS } from "./data.mjs";
+
+// Same default as src/common/site.ts. Both hosts serve the same build, so the
+// canonical host has to be pinned rather than read off window.location.
+export const SITE_URL = (
+  process.env.VITE_SITE_URL || "https://web-frameworks-benchmark.netlify.app"
+).replace(/\/$/, "");
+
+export const absolute = (path) => `${SITE_URL}${path}`;
+
+export const escapeHtml = (value) =>
+  String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+const thousands = (value) =>
+  Math.round(value)
+    .toString()
+    .replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+
+const bytes = (value) => {
+  const units = ["B", "kB", "MB", "GB", "TB"];
+  let index = 0;
+  let size = value;
+  while (size >= 1024 && index < units.length - 1) {
+    size /= 1024;
+    index++;
+  }
+  return `${size.toFixed(index ? 2 : 0)} ${units[index]}`;
+};
+
+// Latencies are stored in seconds, the app shows them in milliseconds.
+export const formatMetric = (kind, value) => {
+  if (value == null || Number.isNaN(value)) return "n/a";
+  if (kind === "latency") return `${(value * 1000).toFixed(2)} ms`;
+  if (kind === "bytes") return bytes(value);
+  return thousands(value);
+};
+
+const STYLE = `
+:root{--color-primary:#1c73bb;--color-border:lightgray;--color-muted:#5b6570}
+*{box-sizing:border-box}
+body{margin:0;padding:0 16px 25vh;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;-webkit-font-smoothing:antialiased;line-height:1.5}
+.container{max-width:1100px;margin:0 auto}
+a{color:var(--color-primary)}
+h1,h2,h3{font-weight:300;line-height:1.2;margin:1.5rem 0 .5rem}
+h1{font-size:2rem}h2{font-size:1.6rem}h3{font-size:1.3rem}
+@media (width >= 1024px){h1{font-size:2.6rem}h2{font-size:2rem}h3{font-size:1.5rem}}
+header{text-align:center;padding-top:16px}
+.nav-links{list-style:none;padding:0;margin:8px 0}
+.nav-links li{display:inline-block;margin:0 12px}
+.nav-links a{text-decoration:none;font-size:1.1rem}
+hr{border:0;border-top:1px solid var(--color-border);margin:24px 0}
+nav.crumbs{font-size:.9rem;color:var(--color-muted);margin:16px 0}
+.table-wrap{overflow-x:auto}
+table{border-collapse:collapse;width:100%;font-size:.95rem}
+caption{text-align:left;padding:8px 0;color:var(--color-muted);font-size:.9rem}
+th,td{border-bottom:1px solid var(--color-border);padding:6px 10px;text-align:right;white-space:nowrap}
+th[scope=row],td:first-child,th:first-child{text-align:left}
+thead th{border-bottom:2px solid var(--color-border);font-weight:600}
+tbody tr:hover{background:#f5f8fb}
+.muted{color:var(--color-muted)}
+ul.grid{list-style:none;padding:0;display:grid;gap:4px 16px;grid-template-columns:repeat(auto-fill,minmax(210px,1fr))}
+footer{margin-top:32px;font-size:.9rem;color:var(--color-muted)}
+`.trim();
+
+const NAV = `
+<ul class="nav-links">
+  <li><a href="/">Home</a></li>
+  <li><a href="/result">Benchmark Results</a></li>
+  <li><a href="/compare">Compare Frameworks</a></li>
+  <li><a href="/frameworks/">Frameworks</a></li>
+  <li><a href="https://github.com/the-benchmarker/web-frameworks">GitHub</a></li>
+</ul>`.trim();
+
+export const jsonLd = (data) =>
+  `<script type="application/ld+json">${JSON.stringify(data).replace(
+    /</g,
+    "\\u003c"
+  )}</script>`;
+
+export const breadcrumbs = (trail) =>
+  jsonLd({
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: trail.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: absolute(item.path),
+    })),
+  });
+
+const crumbHtml = (trail) =>
+  `<nav class="crumbs" aria-label="Breadcrumb">${trail
+    .map((item, index) =>
+      index === trail.length - 1
+        ? `<span aria-current="page">${escapeHtml(item.name)}</span>`
+        : `<a href="${item.path}">${escapeHtml(item.name)}</a>`
+    )
+    .join(" &rsaquo; ")}</nav>`;
+
+export const page = ({
+  title,
+  description,
+  path,
+  trail,
+  structured = [],
+  body,
+  benchmark,
+}) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<meta name="description" content="${escapeHtml(description)}">
+<link rel="canonical" href="${absolute(path)}">
+<link rel="icon" href="/favicon.ico">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Web Frameworks Benchmark">
+<meta property="og:title" content="${escapeHtml(title)}">
+<meta property="og:description" content="${escapeHtml(description)}">
+<meta property="og:url" content="${absolute(path)}">
+<meta property="og:image" content="${absolute("/logo512.png")}">
+<meta name="twitter:card" content="summary">
+<style>${STYLE}</style>
+${[breadcrumbs(trail), ...structured].join("\n")}
+</head>
+<body>
+<header class="container">
+<a href="/" style="text-decoration:none;color:inherit"><h1>Web Frameworks Benchmark</h1></a>
+${NAV}
+</header>
+<hr>
+<main class="container">
+${crumbHtml(trail)}
+${body}
+</main>
+<footer class="container">
+<hr>
+<p>Measured with <a href="https://github.com/wg/wrk">wrk</a> (8 threads, 8s timeout, 15s per run)
+at concurrency ${CONCURRENCIES.join(", ")}, on ${escapeHtml(
+  benchmark.hardware?.cpus ?? "?"
+)} cores (${escapeHtml(
+  benchmark.hardware?.cpu_name ?? "unknown CPU"
+)}) running ${escapeHtml(benchmark.hardware?.os?.sysname ?? "Linux")}.
+Data of ${escapeHtml(benchmark.updatedAtDate)}, from
+<a href="https://github.com/the-benchmarker/web-frameworks">the-benchmarker/web-frameworks</a>.
+Machine readable copies: <a href="/data.json">data.json</a>, <a href="/llms.txt">llms.txt</a>.</p>
+</footer>
+</body>
+</html>
+`;
+
+// One row per metric, one column per concurrency level.
+export const metricTable = (framework, caption) => `
+<div class="table-wrap">
+<table>
+<caption>${escapeHtml(caption)}</caption>
+<thead><tr><th scope="col">Metric</th>${CONCURRENCIES.map(
+  (level) => `<th scope="col">Concurrency ${level}</th>`
+).join("")}</tr></thead>
+<tbody>
+${METRICS.map(
+  (metric) =>
+    `<tr><th scope="row">${escapeHtml(metric.title)}</th>${CONCURRENCIES.map(
+      (level) =>
+        `<td>${escapeHtml(
+          formatMetric(metric.kind, framework.levels[level][metric.key])
+        )}</td>`
+    ).join("")}</tr>`
+).join("\n")}
+</tbody>
+</table>
+</div>`;
+
+// One row per framework, ranked on requests per second.
+export const rankingTable = ({
+  frameworks,
+  caption,
+  level = 64,
+  rankField = "rank",
+  showLanguage = true,
+}) => `
+<div class="table-wrap">
+<table>
+<caption>${escapeHtml(caption)}</caption>
+<thead><tr>
+<th scope="col">#</th>
+<th scope="col">Framework</th>
+${showLanguage ? '<th scope="col">Language</th>' : ""}
+<th scope="col">Requests / second</th>
+<th scope="col">P50 latency</th>
+<th scope="col">P99 latency</th>
+<th scope="col">HTTP errors</th>
+</tr></thead>
+<tbody>
+${frameworks
+  .map(
+    (framework) => `<tr>
+<td>${framework[rankField][level]}</td>
+<th scope="row"><a href="${framework.path}">${escapeHtml(
+      framework.label
+    )}</a> <span class="muted">${escapeHtml(framework.version)}</span></th>
+${
+  showLanguage
+    ? `<td><a href="${framework.language.path}">${escapeHtml(
+        framework.language.label
+      )}</a></td>`
+    : ""
+}
+<td>${escapeHtml(
+      formatMetric("rps", framework.levels[level].total_requests_per_s)
+    )}</td>
+<td>${escapeHtml(
+      formatMetric("latency", framework.levels[level].percentile50)
+    )}</td>
+<td>${escapeHtml(
+      formatMetric("latency", framework.levels[level].percentile99)
+    )}</td>
+<td>${escapeHtml(
+      formatMetric("count", framework.levels[level].http_errors)
+    )}</td>
+</tr>`
+  )
+  .join("\n")}
+</tbody>
+</table>
+</div>`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter, Route, Routes } from "react-router";
 
 import Home from "./views/Home";
 import AppHeader from "./components/AppHeader";
+import Seo from "./components/Seo";
 import ScrollToTop from "./components/ScrollToTop";
 import { NuqsAdapter } from "nuqs/adapters/react-router/v7";
 import KeepAliveRouteOutlet from "keepalive-for-react-router";
@@ -62,6 +63,7 @@ function App() {
   return (
     <NuqsAdapter>
       <BrowserRouter>
+        <Seo />
         <AppHeader onHistoryChange={fetchBenchmarkData} />
         <ScrollToTop />
         {isLoading && <div className="loader">Loading...</div>}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from "./interfaces";
 export * from "./data";
 export * from "./formatter";
+export * from "./site";

--- a/src/common/site.ts
+++ b/src/common/site.ts
@@ -1,0 +1,6 @@
+// The build is served from more than one host, so the canonical URL has to be
+// pinned instead of read off window.location. Keep in sync with the default in
+// scripts/seo/render.mjs.
+export const SITE_URL = (
+  import.meta.env.VITE_SITE_URL || "https://web-frameworks-benchmark.netlify.app"
+).replace(/\/$/, "");

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -41,6 +41,10 @@ function NavBar({ onHistoryChange }: Props) {
             <Link to="/compare">Compare Frameworks</Link>
           </li>
           <li>
+            {/* Static, pre-rendered pages: a full page load, not a <Link>. */}
+            <a href="/frameworks/">Frameworks</a>
+          </li>
+          <li>
             <a
               href="https://github.com/the-benchmarker/website"
               target="_blank"

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+import { SITE_URL } from "../common";
+
+interface Meta {
+  title: string;
+  description: string;
+}
+
+const DEFAULT_META: Meta = {
+  title: "Web Frameworks Benchmark",
+  description:
+    "Web Frameworks Benchmark. There are many frameworks, each one comes with its own advantages and drawbacks. The purpose of this project is to identify them and attempt to measure their differences (performance is only one metric).",
+};
+
+const META: Record<string, Meta> = {
+  "/result": {
+    title: "Benchmark results - Web Frameworks Benchmark",
+    description:
+      "Requests per second and latency percentiles of every benchmarked web framework, at concurrency 64, 256 and 512. Filter by language or framework and sort on any metric.",
+  },
+  "/compare": {
+    title: "Compare frameworks - Web Frameworks Benchmark",
+    description:
+      "Compare web frameworks side by side on throughput and latency percentiles, at concurrency 64, 256 and 512.",
+  },
+};
+
+const setMeta = (name: string, content: string) => {
+  let tag = document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
+  if (!tag) {
+    tag = document.createElement("meta");
+    tag.name = name;
+    document.head.appendChild(tag);
+  }
+  tag.content = content;
+};
+
+const setCanonical = (href: string) => {
+  let tag = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!tag) {
+    tag = document.createElement("link");
+    tag.rel = "canonical";
+    document.head.appendChild(tag);
+  }
+  tag.href = href;
+};
+
+/**
+ * Gives each route its own title, description and canonical URL. The app is a
+ * single HTML file, so without this every route is indexed under the home page
+ * title, and every filter in the query string looks like a separate page.
+ */
+function Seo() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const path = pathname.replace(/\/$/, "") || "/";
+    const meta = META[path] || DEFAULT_META;
+
+    document.title = meta.title;
+    setMeta("description", meta.description);
+    // Query string dropped on purpose: the filters do not change the content.
+    setCanonical(`${SITE_URL}${path === "/" ? "/" : path}`);
+  }, [pathname]);
+
+  return null;
+}
+
+export default Seo;


### PR DESCRIPTION
Today `view-source:` on any URL of the site is `<div id="root"></div>`. All three routes share one title and one description, there is no canonical and no sitemap, and none of the 358 frameworks has a page of its own, so a search for "fastify benchmark" has nothing to find.

`npm run build` now runs a generator after `vite build`. It reads `data.min.json` and writes a static, no-JavaScript page per framework (`/frameworks/<language>/<framework>/`) and per language, with the metrics in a real `<table>` and JSON-LD (SoftwareApplication, Dataset, BreadcrumbList, ItemList). It also writes `sitemap.xml`, a `robots.txt` with the sitemap line, `llms.txt`, `llms-full.txt` and `data.json`, and adds canonical, Open Graph and JSON-LD plus a `<noscript>` top 25 to `dist/index.html`. In the app a small `Seo` component gives `/result` and `/compare` their own title, description and canonical.

Netlify and Vercel both serve static files before the SPA fallback, so the existing routes are untouched. Checked on the built output: 390 pages, 810 JSON-LD blocks that all parse, no broken internal link, and headless Chrome still boots the app on `/`, `/result` and `/compare`.

Two notes. The pages carry the data of the build, so they need a rebuild when the benchmark is re-run. And the Netlify deploy is currently serving a bundle from before the Vite migration, so none of this will be visible until that is fixed.
<img width="776" height="777" alt="image" src="https://github.com/user-attachments/assets/faf6666e-2c7c-40e6-bfb9-dfd9fd2917ee" />
<img width="766" height="778" alt="image" src="https://github.com/user-attachments/assets/7a8c7839-7c01-46bb-bc0c-6f721eb95abf" />
<img width="766" height="782" alt="image" src="https://github.com/user-attachments/assets/9658bf3a-93c1-46d3-a680-414cd86143ea" />
<img width="742" height="770" alt="image" src="https://github.com/user-attachments/assets/2f5693a4-04dc-46ea-88d1-ae0f692d0f7c" />

