### PR TITLE
Replace wrk with zrk

### DIFF
--- a/scripts/seo/build.mjs
+++ b/scripts/seo/build.mjs
@@ -152,7 +152,7 @@ const languagePage = (language, benchmark) => {
   const fastest = language.frameworks[0];
   const description =
     `Benchmark results for ${language.frameworks.length} ${language.label} web frameworks, ` +
-    `measured with wrk at concurrency ${CONCURRENCIES.join(", ")}. Fastest at concurrency ` +
+    `measured with zrk at concurrency ${CONCURRENCIES.join(", ")}. Fastest at concurrency ` +
     `${CONCURRENCIES[0]}: ${fastest.label} with ${formatMetric(
       "rps",
       fastest.levels[CONCURRENCIES[0]].total_requests_per_s
@@ -220,7 +220,7 @@ const hubPage = (benchmark) => {
   const top = [...benchmark.frameworks].sort((a, b) => a.rank[level] - b.rank[level]).slice(0, 50);
   const description =
     `Benchmark results for ${benchmark.frameworks.length} web frameworks in ` +
-    `${benchmark.languages.length} languages, measured with wrk at concurrency ` +
+    `${benchmark.languages.length} languages, measured with zrk at concurrency ` +
     `${CONCURRENCIES.join(", ")}. Data of ${benchmark.updatedAtDate}.`;
 
   const body = `
@@ -292,7 +292,7 @@ const patchIndex = async (benchmark) => {
   const top = [...benchmark.frameworks].sort((a, b) => a.rank[level] - b.rank[level]).slice(0, 25);
   const description =
     `Performance comparison of ${benchmark.frameworks.length} web frameworks in ` +
-    `${benchmark.languages.length} languages, measured with wrk at concurrency ` +
+    `${benchmark.languages.length} languages, measured with zrk at concurrency ` +
     `${CONCURRENCIES.join(", ")}. Data of ${benchmark.updatedAtDate}.`;
 
   const head = `
@@ -410,7 +410,7 @@ const llms = (benchmark) => {
 
 > Throughput and latency of ${benchmark.frameworks.length} web frameworks in ${
     benchmark.languages.length
-  } languages, all serving the same two routes from a Docker container, measured with wrk (8 threads, 15 seconds) at concurrency ${CONCURRENCIES.join(
+  } languages, all serving the same two routes from a Docker container, measured with zrk (8 threads, 15 seconds) at concurrency ${CONCURRENCIES.join(
     ", "
   )}. Run by The Benchmarker. Data of ${benchmark.updatedAtDate}.
 
@@ -459,7 +459,7 @@ const llmsFull = (benchmark) => {
     `# Web Frameworks Benchmark, full results`,
     ``,
     `Data of ${benchmark.updatedAtDate}. ${benchmark.frameworks.length} frameworks, ${benchmark.languages.length} languages.`,
-    `Measured with wrk, 8 threads, 8s timeout, 15s per run, at concurrency ${CONCURRENCIES.join(", ")}.`,
+    `Measured with zrk, 8 threads, 8s timeout, 15s per run, at concurrency ${CONCURRENCIES.join(", ")}.`,
     `Hardware: ${benchmark.hardware?.cpus ?? "?"} cores (${
       benchmark.hardware?.cpu_name ?? "unknown CPU"
     }), ${benchmark.hardware?.os?.sysname ?? "Linux"}.`,

--- a/scripts/seo/data.mjs
+++ b/scripts/seo/data.mjs
@@ -7,7 +7,7 @@ const DATA_URL =
   "https://raw.githubusercontent.com/the-benchmarker/web-frameworks/master/data.min.json";
 const CACHE_FILE = new URL("../../node_modules/.cache/seo/data.min.json", import.meta.url);
 
-// The three concurrency levels wrk is run with, see the "Technical Details"
+// The three concurrency levels zrk is run with, see the "Technical Details"
 // section of the home page.
 export const CONCURRENCIES = [64, 256, 512];
 

--- a/scripts/seo/render.mjs
+++ b/scripts/seo/render.mjs
@@ -143,7 +143,7 @@ ${body}
 </main>
 <footer class="container">
 <hr>
-<p>Measured with <a href="https://github.com/wg/wrk">wrk</a> (8 threads, 8s timeout, 15s per run)
+<p>Measured with <a href="https://zoxy.io/zrk/">zrk</a> (8 threads, 8s timeout, 15s per run)
 at concurrency ${CONCURRENCIES.join(", ")}, on ${escapeHtml(
   benchmark.hardware?.cpus ?? "?"
 )} cores (${escapeHtml(

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -76,7 +76,7 @@ export default function Home({ updateDate, hardware }: Props) {
             <code>ruby</code>, all tools are made in <code>ruby</code>
           </li>
           <li>
-            <code>wrk</code>, results are collected using <code>wrk</code>
+            <code>zrk</code>, results are collected using <code>zrk</code>
           </li>
           <li>
             <code>postgresql</code>, results are stored in{" "}
@@ -96,8 +96,8 @@ export default function Home({ updateDate, hardware }: Props) {
         <h3>Technical Details</h3>
         <p>
           All frameworks are benchmarked using{" "}
-          <a href="https://github.com/wg/wrk" target="_blank" rel="noreferrer">
-            wrk
+          <a href="https://zoxy.io/zrk/" target="_blank" rel="noreferrer">
+            zrk
           </a>{" "}
           (threads: 8, timeout: 8, duration: 15 seconds) with <b>64</b>,{" "}
           <b>256</b>, and <b>512</b> concurrency.


### PR DESCRIPTION
## Summary
- Replace all wrk references/links with zrk (https://zoxy.io/zrk/)

## Test plan
- [ ] Verify rendered pages show zrk instead of wrk